### PR TITLE
Fix a bug on some Apache/PHP configs

### DIFF
--- a/data/Movie.php
+++ b/data/Movie.php
@@ -105,7 +105,8 @@ class Movie{
 	 * 	@return string
 	 */
 	public function getTrailer() {
-		return $this->getTrailers()['youtube'][0]['source'];
+		$trailers = $this->getTrailers();
+		return $trailers['youtube'][0]['source'];
 	}
 
 	/**


### PR DESCRIPTION
As originally written, this threw "child pid 19382 exit signal Segmentation fault (11)" errors on one of my servers. It took all day to find the culprit. Accessing array directly on method -- getArray()['elem'] -- is problematic in some configurations.
